### PR TITLE
chore: update kotlin to 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@
 .externalNativeBuild
 .cxx
 local.properties
+.kotlin
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.kotlinJvm) apply false
+    alias(libs.plugins.composeCompiler) apply false
 }
 
 ext {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,21 @@
 [versions]
 agp = "8.2.2"
-kotlin = "1.9.23"
-core-ktx = "1.13.0"
+kotlin = "2.0.0"
+core-ktx = "1.13.1"
 junit = "4.13.2"
 androidx-test-ext-junit = "1.1.5"
 espresso-core = "3.5.1"
 appcompat = "1.6.1"
 leakcanary = "2.13"
-material = "1.11.0"
+material = "1.12.0"
 constraintlayout = "2.1.4"
 navigation-fragment-ktx = "2.7.7"
 tapsell = "1.0.1-beta06"
-lifecycle-livedata-ktx = "2.7.0"
-lifecycle-viewmodel-ktx = "2.7.0"
-lifecycle-runtime-ktx = "2.7.0"
+lifecycle-livedata-ktx = "2.8.0"
+lifecycle-viewmodel-ktx = "2.8.0"
+lifecycle-runtime-ktx = "2.8.0"
 activity-compose = "1.9.0"
-compose-bom = "2024.04.01"
+compose-bom = "2024.05.00"
 coil = "2.6.0"
 
 [libraries]
@@ -60,6 +60,7 @@ espresso-core = { group = "androidx.test.espresso", name = "espresso-core", vers
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
 [bundles]
 

--- a/sample-jetpack-compose/build.gradle.kts
+++ b/sample-jetpack-compose/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.kotlinAndroid)
+    alias(libs.plugins.composeCompiler)
 }
 
 android {
@@ -70,18 +71,15 @@ android {
         compose = true
         buildConfig = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
+    composeCompiler {
+        enableStrongSkippingMode = true
+        reportsDestination = layout.buildDirectory.dir("compose_compiler")
+        stabilityConfigurationFile = rootProject.layout.projectDirectory.file("stability_config.conf")
     }
     lint {
         checkReleaseBuilds = false
         abortOnError = false
     }
-//    packaging {
-//        resources {
-//            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-//        }
-//    }
 }
 
 dependencies {


### PR DESCRIPTION
## Overview
- Update Kotlin version to 2.0.0
- Update compose version to 2024.05
- Enable `enableStrongSkippingMode` to allow composables with unstable parameters to be skipped
