### PR TITLE
chore: update SDK to v1.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,24 +1,23 @@
 [versions]
-agp = "8.11.1"
-kotlin = "2.2.0"
+agp = "8.13.0"
+kotlin = "2.2.20"
 core-ktx = "1.16.0"
 junit = "4.13.2"
-androidx-test-ext-junit = "1.2.1"
-espresso-core = "3.6.1"
+androidx-test-ext-junit = "1.3.0"
+espresso-core = "3.7.0"
 appcompat = "1.7.1"
 leakcanary = "2.14"
-material = "1.12.0"
+material = "1.13.0"
 constraintlayout = "2.2.1"
-navigation-fragment-ktx = "2.9.2"
+navigation-fragment-ktx = "2.9.4"
 google-appset = "16.1.0"
 google-ads-identifier = "18.2.0"
-tapsell = "1.0.2-beta09"
-lifecycle = "2.9.2"
+tapsell = "1.1.0"
+lifecycle = "2.9.3"
 activity = "1.10.1"
-activity-compose = "1.10.1"
-compose-bom = "2025.07.00"
+activity-compose = "1.11.0"
+compose-bom = "2025.09.00"
 coil = "2.7.0"
-appium = "9.5.0"
 
 [libraries]
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-fragment-ktx" }
@@ -60,8 +59,6 @@ ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 material3 = { group = "androidx.compose.material3", name = "material3" }
 coil = { module = "io.coil-kt:coil", version.ref = "coil" }
-
-appium = { module = "io.appium:java-client", version.ref = "appium" }
 
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/sample-kotlin/build.gradle.kts
+++ b/sample-kotlin/build.gradle.kts
@@ -90,7 +90,6 @@ dependencies {
     implementation(libs.adapter.chartboost)
     implementation(libs.adapter.wortise)
 
-    testImplementation(libs.appium)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.espresso.core)


### PR DESCRIPTION
## Overview

- Upgraded Tapsell Legacy adapter version to `v4.9.13`: Fixed ANR issue in video ads by migrating
  Android Media Player to `ExoPlayer`.
- Enhanced Video Player load performance
- Suppress GooglePlayService out-dated notification when using Google's `TrustedTime` api.
- Update dependencies
